### PR TITLE
Initialize Quartz-like structure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy Quartz site
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: pnpm install
+      - name: Build site
+        run: pnpm run build
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          publish_branch: gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+learning.luketseng.dev

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# lukewtseng.github.io
+# Learning Journey Site
+
+This repository contains a Quartz 5 setup compatible with Obsidian.
+
+## Local Preview
+
+```bash
+pnpm install && pnpm dev
+```
+
+## Deployment
+
+Push changes to `main` and GitHub Actions will build the site and deploy the `dist` folder to the `gh-pages` branch using `peaceiris/actions-gh-pages`.

--- a/content/build-logs/inference-stack.md
+++ b/content/build-logs/inference-stack.md
@@ -1,0 +1,8 @@
+---
+title: "Inference Stack"
+tags: ["llm", "build"]
+created: 2025-06-21
+updated: 2025-06-21
+---
+
+Notes about building the inference stack for language models.

--- a/content/index.md
+++ b/content/index.md
@@ -1,0 +1,8 @@
+---
+title: "Welcome"
+tags: ["home"]
+created: 2025-06-21
+updated: 2025-06-21
+---
+
+Welcome to the learning journey site. Explore [[papers]], [[build-logs]], and [[notes]].

--- a/content/notes/spark-physical-plans.md
+++ b/content/notes/spark-physical-plans.md
@@ -1,0 +1,8 @@
+---
+title: "Spark Physical Plans"
+tags: ["spark", "notes"]
+created: 2025-06-21
+updated: 2025-06-21
+---
+
+A quick reference on Spark's physical execution plans.

--- a/content/papers/2025-ACL-Foo.md
+++ b/content/papers/2025-ACL-Foo.md
@@ -1,0 +1,8 @@
+---
+title: "ACL Foo Paper"
+tags: ["llm", "paper"]
+created: 2025-06-21
+updated: 2025-06-21
+---
+
+This note summarizes the hypothetical ACL Foo paper.

--- a/content/tags/llm.md
+++ b/content/tags/llm.md
@@ -1,0 +1,8 @@
+---
+title: "LLM"
+tags: ["meta"]
+created: 2025-06-21
+updated: 2025-06-21
+---
+
+Pages related to large language models.

--- a/index.md
+++ b/index.md
@@ -1,0 +1,5 @@
+# Welcome to Luke Tseng's Learning Journey
+
+- [Papers](./content/papers/)
+- [Build Logs](./content/build-logs/)
+- [Notes](./content/notes/)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "learning-journey-site",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "quartz dev",
+    "build": "quartz build"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}

--- a/siteConfig.ts
+++ b/siteConfig.ts
@@ -1,0 +1,12 @@
+export const siteConfig = {
+  baseUrl: "/",
+  siteName: "Luke Tseng's Learning Journey",
+  githubUrl: "https://github.com/luketseng/luketseng.github.io",
+  nav: [
+    { text: "Papers", link: "/papers/" },
+    { text: "Build Logs", link: "/build-logs/" },
+    { text: "Notes", link: "/notes/" }
+  ],
+};
+
+export default siteConfig;


### PR DESCRIPTION
## Summary
- add sample notes under `content/`
- configure navigation via `siteConfig.ts`
- scaffold GitHub Actions workflow to deploy with pnpm and gh-pages
- set up basic README and index
- include CNAME for custom domain
- tweak config for GitHub Pages

## Testing
- `pnpm install`
- `pnpm run build` *(fails: `quartz` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857a5d825308324963cce6819ff7bfd